### PR TITLE
Fix boolean writing

### DIFF
--- a/server/enip/client.py
+++ b/server/enip/client.py
@@ -135,9 +135,22 @@ def int_validate( x, lo, hi ):
     assert lo <= res <= hi, "Invalid %d; not in range (%d,%d)" % ( res, lo, hi)
     return res
 
+def bool_validate( b ):
+    try:
+        res = int( b ) != 0
+        return res
+    except ValueError:
+        pass
+    lowered = b.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    raise ValueError("Invalid %s; could not be interpreted as boolean" % b)
+
 CIP_TYPES			= {
     'SSTRING':	(enip.SSTRING.tag_type,	0,				str ),
-    'BOOL':	(enip.BOOL.tag_type,	enip.BOOL.struct_calcsize,	bool ),
+    'BOOL':	(enip.BOOL.tag_type,	enip.BOOL.struct_calcsize,	bool_validate ),
     'REAL': 	(enip.REAL.tag_type,	enip.REAL.struct_calcsize,	float ),
     'DINT':	(enip.DINT.tag_type,	enip.DINT.struct_calcsize,	lambda x: int_validate( x, -2**31, 2**32-1 )), # extra range
     'UDINT':	(enip.UDINT.tag_type,	enip.UDINT.struct_calcsize,	lambda x: int_validate( x,  0,     2**32-1 )),


### PR DESCRIPTION
Writing boolean tags is broken so that whatever value specified, it will always be interpreted as True. This fix allows "0" or "false" to write false, and any other number or "true" to write true. Not sure what should be allowed exactly.