### PR TITLE
await module and method renamed to await_ (issue #55)

### DIFF
--- a/modbus_test.py
+++ b/modbus_test.py
@@ -16,7 +16,7 @@ except Exception:
     logging.warning( "Failed to import fcntl; skipping simulated Modbus/TCP PLC tests" )
 
 from . import misc
-from .tools.await import waitfor
+from .tools.await_ import waitfor
 
 RTU_WAIT			= 2.0  # How long to wait for the simulator
 RTU_LATENCY			= 0.05 # poll for command-line I/O response 

--- a/remote_test.py
+++ b/remote_test.py
@@ -32,7 +32,7 @@ import traceback
 
 import pytest
 
-from .tools.await import waitfor
+from .tools.await_ import waitfor
 from .modbus_test import start_modbus_simulator, has_o_nonblock, run_plc_modbus_polls
 from .remote.plc import poller_simulator, PlcOffline
 from .remote.io	import motor

--- a/serial_test.py
+++ b/serial_test.py
@@ -90,7 +90,7 @@ try:
 except ImportError:
     logging.warning( "Failed to import pymodbus module; skipping Modbus/TCP related tests; run 'pip install pymodbus'" )
 
-from .tools.await import waitfor
+from .tools.await_ import waitfor
 from .modbus_test import start_modbus_simulator, has_o_nonblock, run_plc_modbus_polls
 if has_pymodbus and has_pyserial:
     from .remote.pymodbus_fixes import modbus_client_rtu, modbus_rtu_framer_collecting

--- a/server/enip/client.py
+++ b/server/enip/client.py
@@ -30,7 +30,7 @@ __license__                     = "Dual License: GPLv3 (or later) and Commercial
 
 __all__				= ['parse_int', 'parse_path', 'parse_path_elements', 'parse_path_component',
                                    'format_path', 'format_context', 'parse_context', 'CIP_TYPES', 'parse_operations',
-                                   'client', 'await', 'connector', 'recycle', 'main']
+                                   'client', 'await_', 'connector', 'recycle', 'main']
 
 """enip.client	-- EtherNet/IP client API and module entry point
 
@@ -850,7 +850,7 @@ class client( object ):
         return data
 
 
-def await( cli, timeout=None ):
+def await_( cli, timeout=None ):
     """Await a response on an iterable client() instance (for timeout seconds, or forever if None).
     Returns (response,elapsed).  A 'timeout' may be supplied, of:
 
@@ -916,7 +916,7 @@ class connector( client ):
                 self.register( timeout=None if timeout is None else max( 0, timeout - elapsed_req ))
                 # Await the CIP response for remainder of timeout
                 elapsed_req	= cpppo.timer() - begun
-                data,elapsed_rpy= await( self, timeout=None if timeout is None else max( 0, timeout - elapsed_req ))
+                data,elapsed_rpy= await_( self, timeout=None if timeout is None else max( 0, timeout - elapsed_req ))
 
             assert data is not None, "Failed to receive any response"
             assert 'enip.status' in data, "Failed to receive EtherNet/IP response"
@@ -1112,7 +1112,7 @@ class connector( client ):
             if self.profiler:
                 self.profiler.disable()
             try:
-                response,elapsed	= await( self, timeout=timeout )
+                response,elapsed	= await_( self, timeout=timeout )
             finally:
                 if self.profiler:
                     self.profiler.enable()
@@ -1607,7 +1607,7 @@ which is required to carry this Send/Route Path data. """ )
             counter		= 0
             while ( elapsed is None or elapsed < timeout ):
                 remains		= timeout - ( elapsed or 0 )
-                reply,_		= await( connection, timeout=remains )
+                reply,_		= await_( connection, timeout=remains )
                 if reply:
                     print( "%s %2d from %r: %s" % (
                         desc, counter, reply.peer, enip.enip_format( reply.get( path, reply ))))

--- a/server/enip/client_test.py
+++ b/server/enip/client_test.py
@@ -107,7 +107,7 @@ def test_client_timeout():
     # Await the termination of the Process, which should happen just after .5s.
     beg				= misc.timer()
     try:
-        assert all( tools.await.existence( terms=[ lambda: not conn.is_alive() ], timeout=1.0 )), \
+        assert all( tools.await_.existence( terms=[ lambda: not conn.is_alive() ], timeout=1.0 )), \
             "enip.client.connector to non-existent host didn't time out; took: %.3fs" % ( misc.timer() - beg )
     finally:
         conn.terminate()

--- a/server/enip/get_attribute.py
+++ b/server/enip/get_attribute.py
@@ -373,7 +373,7 @@ class proxy( object ):
         """
         with self.gateway as connection: # waits 'til any Thread's txn. completes
             connection.list_identity( timeout=self.timeout )
-            rsp,ela		= client.await( connection, timeout=self.timeout )
+            rsp,ela		= client.await_( connection, timeout=self.timeout )
             assert rsp, \
                 "No response to List Identity within timeout: %r" % ( self.timeout )
             return rsp,ela

--- a/server/enip/list_identity_simple.py
+++ b/server/enip/list_identity_simple.py
@@ -18,7 +18,7 @@ host			= sys.argv[1] if sys.argv[1:] else '255.255.255.255'
 with client.client( host=host, udp=True, broadcast=True ) as conn:
     conn.list_identity( timeout=timeout )
     while True:
-        response,elapsed= client.await( conn, timeout=timeout )
+        response,elapsed= client.await_( conn, timeout=timeout )
         if response:
             print( enip.enip_format( response ))
         else:

--- a/server/enip/list_services.py
+++ b/server/enip/list_services.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
                 connection.list_interfaces()
             connection.shutdown() # starts a client-initiated clean shutdown for TCP/IP
             while True:
-                response,ela	= client.await( connection, timeout=timeout )
+                response,ela	= client.await_( connection, timeout=timeout )
                 if response:
                     print( enip.enip_format( response ))
                 else:

--- a/server/logix_test.py
+++ b/server/logix_test.py
@@ -749,7 +749,7 @@ def logix_remote( count, svraddr, kwargs ):
     begun			= cpppo.timer()
     with cli:
         cli.register( timeout=timeout )
-        data,elapsed		= client.await( cli, timeout=timeout )
+        data,elapsed		= client.await_( cli, timeout=timeout )
     log.normal( "Client Register Rcvd %7.3f/%7.3fs: %r", elapsed, timeout, data )
     assert data is not None and 'enip.CIP.register' in data, "Failed to receive Register response"
     assert data.enip.status == 0, "Register response indicates failure: %s" % data.enip.status
@@ -763,7 +763,7 @@ def logix_remote( count, svraddr, kwargs ):
             begun		= cpppo.timer()
             cli.read( path=[{'symbolic': 'SCADA'}, {'element': 12}],
                       elements=201, offset=2, timeout=timeout )
-            data,elapsed	= client.await( cli, timeout=timeout )
+            data,elapsed	= client.await_( cli, timeout=timeout )
             log.normal( "Client ReadFrg. Rcvd %7.3f/%7.3fs: %r", elapsed, timeout, data )
 
     duration			= cpppo.timer() - start

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -23,4 +23,4 @@ __email__                       = "perry@hardconsulting.com"
 __copyright__                   = "Copyright (c) 2015 Hard Consulting Corporation"
 __license__                     = "Dual License: GPLv3 (or later) and Commercial (see LICENSE)"
 
-__all__				= ["await"]
+__all__				= ["await_"]

--- a/tools/await_.py
+++ b/tools/await_.py
@@ -43,13 +43,13 @@ class existence( object ):
     Assuming args.wait is a list of 0 or more #[.#] numeric or 'filename[%regex]' terms, to process
     the condition terms 'til the first failure, and then raise an Exception:
 
-        assert all( await.existence()( *args.wait )), \
+        assert all( await_.existence()( *args.wait )), \
             "Failed awaiting <timeout> and/or <filename>[%<regex>]: %r" % ( args.wait )
 
     To process each term and log the details of which term failed (the default str() representation 
-    of an await.existence instance, is the last term awaited):
+    of an await_.existence instance, is the last term awaited):
     
-        waiter			= await.existence( terms=args.wait )
+        waiter			= await_.existence( terms=args.wait )
         for success in waiter:
             assert success, \
                 "Failed awaiting <timeout> and/or <filename>[%<regex>]: %s" % ( waiter )

--- a/tools/await_test.py
+++ b/tools/await_test.py
@@ -5,21 +5,21 @@ from __future__ import division
 import os
 
 from ..misc import timer, near
-from . import await
+from . import await_
 
 def test_await():
-    assert all( await.existence()( "/etc/hosts" ))
-    assert all( await.existence()( __file__ + "%^def test_await" ))
+    assert all( await_.existence()( "/etc/hosts" ))
+    assert all( await_.existence()( __file__ + "%^def test_await" ))
 
-    assert not all( await.existence()( .1, __file__ + ".boo" )) # timeout on filename
-    assert not all( await.existence()( .1, __file__ + "%^boo" )) # timeout on regex
+    assert not all( await_.existence()( .1, __file__ + ".boo" )) # timeout on filename
+    assert not all( await_.existence()( .1, __file__ + "%^boo" )) # timeout on regex
 
     # Ensure timeout delay is computed correctly (exponential back-off)
 
     # A bare .25-second timeout.  The timeout delay should implemented after
     # yielding last value, but before raising StopIteration.
     v			= .25
-    a			= iter( await.existence()( str( v )))
+    a			= iter( await_.existence()( str( v )))
     beg			= timer()
     assert next( a ) == True
     assert 0.0 <= timer() - beg < v * 0.1
@@ -32,7 +32,7 @@ def test_await():
 
     # A 100 second timeout on an existing file (this one)
     v			= 100
-    a			= iter( await.existence()( str( v ), __file__ ))
+    a			= iter( await_.existence()( str( v ), __file__ ))
     beg			= timer()
     assert next( a ) == True
     assert 0.0 <= timer() - beg < v * 0.1
@@ -69,7 +69,7 @@ def test_await_presence():
     # are treated as if they don't yet exist.
     beg			= timer()
     iamroot		= os.geteuid() == 0
-    assert all( await.existence()( .1, "/etc/shadow" )) == iamroot
+    assert all( await_.existence()( .1, "/etc/shadow" )) == iamroot
     if iamroot:
         assert timer() - beg < .1
     else:
@@ -77,29 +77,29 @@ def test_await_presence():
 
     # We can reverse presence detection.  Check that we can fail due to a file that exists
     beg			= timer()
-    assert all( await.existence( terms=[ .1, __file__ ], presence=False )) == False
+    assert all( await_.existence( terms=[ .1, __file__ ], presence=False )) == False
     assert .1 <= timer() - beg < .2
     # But a file that doesn't exist completes right away
     beg			= timer()
-    assert all( await.existence( terms=[ __file__+"asdfds" ], presence=False )) == True
+    assert all( await_.existence( terms=[ __file__+"asdfds" ], presence=False )) == True
     assert  timer() - beg < .1
     beg			= timer()
-    assert all( await.existence( terms=[ "+inf", __file__+"asdfds" ], presence=False )) == True
+    assert all( await_.existence( terms=[ "+inf", __file__+"asdfds" ], presence=False )) == True
     assert  timer() - beg < .1
     beg			= timer()
-    assert all( await.existence( terms=[ ".1", __file__+"asdfds" ], presence=False )) == True
+    assert all( await_.existence( terms=[ ".1", __file__+"asdfds" ], presence=False )) == True
     assert  timer() - beg < .1
     # and a failing regex is the same as not existing
     beg			= timer()
-    assert all( await.existence( terms=[ .1, __file__+"%^asdfsdaf" ], presence=False )) == True
+    assert all( await_.existence( terms=[ .1, __file__+"%^asdfsdaf" ], presence=False )) == True
     assert  timer() - beg < .1
     # but a matching regex has to be timed out and fails
     beg			= timer()
-    assert all( await.existence( terms=[ .1, __file__+"%^def test_await_presence" ], presence=False )) == False
+    assert all( await_.existence( terms=[ .1, __file__+"%^def test_await_presence" ], presence=False )) == False
     assert .1 <= timer() - beg < .2
 
 def test_await_duration():
-    truth,timing	= next( await.duration( await.existence( [ lambda: True ], timeout=1.0 )))
+    truth,timing	= next( await_.duration( await_.existence( [ lambda: True ], timeout=1.0 )))
     assert truth is True and timing <= .01
-    truth,timing	= next( await.duration( await.existence( [ lambda: False ], timeout=.25 )))
+    truth,timing	= next( await_.duration( await_.existence( [ lambda: False ], timeout=.25 )))
     assert truth is False and .25 <= timing <= .25+.01


### PR DESCRIPTION
await module and method renamed to await_ to avoid clash with python 3.7 keyword await (issue #55)

NOTE: this patch consists in an API changes. 