### PR TITLE
Updated pytz to v2018.5

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -71,9 +71,11 @@ help:
 	@echo "  vmware-debian-up	Brings up Jessie VM w/ Docker capability" 
 	@echo "  vmware-debian-ssh	Log in to the VM" 
 
-test:
+test2:
 	$(PY2TEST) || true
+test3:
 	$(PY3TEST) || true
+test: test2 test3
 
 install:
 	$(PY2) setup.py install
@@ -164,6 +166,10 @@ test-%:
 	$(PY2TEST) *$*_test.py
 	$(PY3TEST) *$*_test.py
 
+unit2-%:
+	$(PY2TEST) -k $*
+unit3-%:
+	$(PY3TEST) -k $*
 unit-%:
 	$(PY2TEST) -k $*
 	$(PY3TEST) -k $*

--- a/automata.py
+++ b/automata.py
@@ -234,7 +234,7 @@ class remembering( chaining ):
         if self.memory:
             assert self.memory.pop() == item
         super( remembering, self ).push( item )
-        
+
 
 class decide( object ):
     """A type of object that may be supplied as a state transition target, instead of a state.  It must
@@ -779,9 +779,9 @@ class state( dict ):
         # StopIteration after yielding a transition, or if self is a terminal state
 
     def delegate( self, source, machine=None, path=None, data=None, ending=None ):
-        """Base state class delegate generator does nothing."""
-        raise StopIteration
-        yield None 
+        """Base state class delegate generator does nothing; equivalent to `yield from ()` in Python 3.3+"""
+        return
+        yield
 
     def initialize( self, machine=None, path=None, data=None ):
         """Done once at state entry."""
@@ -1401,7 +1401,7 @@ class regex_bytes( regex ):
 
 
 class string_base( object ):
-    """When combined with a regex class, collects a string matching the regular expression, and puts it
+    r"""When combined with a regex class, collects a string matching the regular expression, and puts it
     in the data artifact at path.context 'string' by default.
 
     The default initial=".*\n", greedy=False configuration scans input only until the regular
@@ -1465,7 +1465,7 @@ class string_base( object ):
         value			= data[subs]
         if isinstance( value, array.array ):
             if value.typecode == 'c':
-                value		= value.tostring()
+                value		= value.tostring() if sys.version_info[0] < 3 else value.tobytes()
             elif value.typecode == 'B':
                 value		= value.tobytes()
             elif value.typecode == 'u':
@@ -1489,7 +1489,7 @@ class integer_base( string_base ):
     def __init__( self, name, initial=None, context="integer", **kwds ):
         assert initial is None, "Cannot specify a sub-machine for %s.%s" % (
             __package__, self.__class__.__name__ )
-        super( integer_base, self ).__init__( name=name, initial="\d+", context=context,
+        super( integer_base, self ).__init__( name=name, initial=r"\d+", context=context,
                                               greedy=True, **kwds )
 
     def terminate( self, exception, machine=None, path=None, data=None ):

--- a/dotdict.py
+++ b/dotdict.py
@@ -79,13 +79,16 @@ class dotdict( dict ):
         self.update( *args, **kwds )
 
     def update( self, *args, **kwds ):
-        """Give each dict and keyword a chance to be converted into a dotdict() layer"""
-        if args:
-            for key, val in dict( *args ).items():
-                self.__setitem__( key, val )
-        if kwds:
-            for key, val in kwds.items():
-                self.__setitem__( key, val )
+        """Give each dict or k,v iterable, and all keywords a chance to be converted into a dotdict() layer.
+
+        """
+        # There is a defect in python 3.7 that erroneously passes back a single dict object passed
+        # to dict.__init__ as the result...   
+        assert 0 <= len( args ) <= 1, "A single dict or iterable of key/value pairs is allowed"
+        if args and isinstance( args[0], dict ) and type(args[0]) is not dict:
+            args = (dict.items( args[0] ),)
+        for key, val in dict( *args, **kwds ).items():
+            self.__setitem__( key, val )
 
     def __dir__( self ):
         """We try to present a sensible .attribute interface.  Therefore, it doesn't make sense for

--- a/history/files.py
+++ b/history/files.py
@@ -516,7 +516,7 @@ class reader( object ):
 
             # Exhausted playback of this history file
             log.debug( "%s Playback complete: %s, line %d", self, f, n )
-            raise StopIteration
+            return # raise StopIteration
 
         finally:
             # On success or failure, every remaining opened file must be closed

--- a/history_test.py
+++ b/history_test.py
@@ -67,6 +67,7 @@ def test_history_timestamp_abbreviations():
         'America/Mazatlan', 'America/Merida', 'America/Mexico_City', 'America/Monterrey',
         'America/Bahia_Banderas', 'America/Cancun', 'America/Chihuahua', 'America/Havana',
         'America/Santa_Isabel', 'America/Grand_Turk', 'America/Cayman', 'America/Port-au-Prince',
+        'America/Metlakatla',
     ]
     #print()
     #print( "America, w/o %r" % ( exclude ))
@@ -99,17 +100,21 @@ def test_history_timestamp_abbreviations():
     assert 'EEST' not in timestamp._tzabbrev
 
     # And all of Europe, w/o some troublesome time zones
-    exclude			= [ 'Europe/Simferopol', 'Europe/Istanbul', 'Europe/Minsk', 'Europe/Chisinau' ]
+    exclude			= [ 'Europe/Simferopol', 'Europe/Istanbul', 'Europe/Minsk', 'Europe/Chisinau', 'Europe/Dublin' ]
     #print()
     #print( "Europe, w/o %r" % ( exclude ))
     abbrev			= timestamp.support_abbreviations( 'Europe', exclude=exclude )
     #print( sorted( abbrev ))
-    if pytz_version < (2016,3):
+    if pytz_version < (2015,2):
+        assert sorted( abbrev ) == ['BST', 'EEST', 'EET', 'MSK', 'SAMT', 'WEST', 'WET']
+    elif pytz_version < (2016,3):
         assert sorted( abbrev ) == ['BST', 'EEST', 'EET', 'IST', 'MSK', 'SAMT', 'WEST', 'WET']
     elif pytz_version < (2016,7):
         assert sorted( abbrev ) == ['BST', 'EEST', 'EET', 'IST', 'MSK', 'SAMT', 'WEST', 'WET']
-    else:
+    elif pytz_version < (2018,5):
         assert sorted( abbrev ) == ['BST', 'EEST', 'EET', 'IST', 'MSK', 'WEST', 'WET']
+    else:
+        assert sorted( abbrev ) == ['BST', 'EEST', 'EET', 'MSK', 'WEST', 'WET']
         
     assert 'EEST' in timestamp._tzabbrev
     try:

--- a/server/enip/client.py
+++ b/server/enip/client.py
@@ -1163,10 +1163,9 @@ class connector( client ):
             # Find the replies in the response; could be single or multiple; should match requests!
             replies		= []
             if response is None:# None response indicates timeout
-                raise StopIteration( "Response Not Received w/in %7.2fs" % (
-                    cpppo.inf if timeout is None else timeout ))
+                return # "Response Not Received w/in %7.2fs" % ( cpppo.inf if timeout is None else timeout )
             elif not response:	# empty response indicates clean EOF
-                raise StopIteration( "Session terminated" )
+                return # "Session terminated" # =~= raise StopIteration( "Session terminated" )
             elif 'enip.status' in response and response.enip.status != 0:
                 raise ENIPStatusError( status=response.enip.status )
             elif 'enip.CIP.send_data.CPF.item[1].unconnected_send.request.multiple.request' in response:

--- a/server/enip/client_test.py
+++ b/server/enip/client_test.py
@@ -110,6 +110,13 @@ def test_client_timeout():
         conn.terminate()
 
 
+def test_dotdict_request():
+    d = dotdict()
+    o = dotdict({'something': 99})
+    d.item = [o,o,o]
+    d2 = dotdict( d )
+
+
 def test_client_api():
     """Performance of executing an operation a number of times on a socket connected
     Logix simulator, within the same Python interpreter (ie. all on a single CPU

--- a/server/enip/parser_test.py
+++ b/server/enip/parser_test.py
@@ -50,7 +50,6 @@ def test_IFACEADDRS():
 
 
 def test_EPATH_single():
-    logging.getLogger().setLevel( logging.DEBUG )
     data			= cpppo.dotdict()
     source			= b'\x12\x0810.0.7.1'
     with parser.EPATH_single() as machine:

--- a/server/enip_test.py
+++ b/server/enip_test.py
@@ -55,7 +55,10 @@ def test_octets():
         assert machine.terminal, "%s: Should have reached terminal state" % machine.name_centered()
         assert i == 4
     assert source.peek() == b'3'[0]
-    assert data.octets.five.input.tostring() == b'abc12'
+    if sys.version_info[0] < 3:
+        assert data.octets.five.input.tostring() == b'abc12'
+    else:
+        assert data.octets.five.input.tobytes() == b'abc12'
 
 
 def test_octets_singly():
@@ -80,7 +83,10 @@ def test_octets_singly():
         assert machine.terminal, "%s: Should have reached terminal state" % machine.name_centered()
         assert i == 9
     assert origin.peek() == b'3'[0]
-    assert data.octets.singly.input.tostring() == b'abc12'
+    if sys.version_info[0] < 3:
+        assert data.octets.singly.input.tostring() == b'abc12'
+    else:
+        assert data.octets.singly.input.tobytes() == b'abc12'
 
 def test_octets_deficient():
     """Scans octets where the source is deficient"""
@@ -143,7 +149,10 @@ def test_words():
         assert machine.terminal, "%s: Should have reached terminal state" % machine.name_centered()
         assert i == 11
     assert origin.peek() == b'z'[0]
-    assert data.words.singly.input.tostring() == b'abc123'
+    if sys.version_info[0] < 3:
+        assert data.words.singly.input.tostring() == b'abc123'
+    else:
+        assert data.words.singly.input.tobytes() == b'abc123'
 
 
 def test_octets_struct():

--- a/server/network.py
+++ b/server/network.py
@@ -392,7 +392,7 @@ def bench( server_func, client_func, client_count,
                 if result:
                     log.warning( "Client failed w/ non-0 result: %s", result )
             except Exception as exc:
-                log.warning( "Client failed w/ Exception: %s", exc )
+                log.exception( "Client failed w/ Exception: %s", exc )
 
 
         failures		= client_count - successes

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
-__version_info__		= ( 4, 0, 2 )
+__version_info__		= ( 4, 0, 3 )
 __version__			= '.'.join( map( str, __version_info__ ))


### PR DESCRIPTION
I only modified the tests to match the answers for the new version of pytz (2018.5) and added an answer for v2014.10 because I happened to have that version and noticed a wrong answer.