### PR TITLE
Support python 3.11, fix bug in CodeType arg order

### DIFF
--- a/misc.py
+++ b/misc.py
@@ -136,41 +136,29 @@ def change_function( function, **kwds ):
 
     will change the func's co_filename to the specified string.
 
-    The types.CodeType constructor differs between Python 2 and 3; see
-    type help(types.CodeType) at the interpreter prompt for information:
-
-    Python2:
-        code(argcount,                nlocals, stacksize, flags, codestring,
-         |        constants, names, varnames, filename, name, firstlineno,
-         |        lnotab[, freevars[, cellvars]])
-
-    Python3:
-        code(argcount, kwonlyargcount, nlocals, stacksize, flags, codestring,
-         |        constants, names, varnames, filename, name, firstlineno,
-         |        lnotab[, freevars[, cellvars]])
-
+    The types.CodeType constructor differs between Python versions; see
+    type help(types.CodeType) at the interpreter prompt for information.
 
     """
-    # Enumerate  all the __code__ attributes in the same order; types.CodeTypes
-    # doesn't accept keyword args, only position.
-    attrs			= [ "co_argcount" ]
-    if sys.version_info[0] >= 3:
-        attrs		       += [ "co_kwonlyargcount" ]
-        if sys.version_info[1] >= 8:
-            attrs	       += [ "co_posonlyargcount" ]
-    attrs		       += [ "co_nlocals",
-                                    "co_stacksize",
-                                    "co_flags",
-                                    "co_code",
-                                    "co_consts",
-                                    "co_names",
-                                    "co_varnames",
-                                    "co_filename",
-                                    "co_name",
-                                    "co_firstlineno",
-                                    "co_lnotab",
-                                    "co_freevars",
-                                    "co_cellvars" ]
+
+    version_lookup = {
+        (2, 7):  ["co_argcount", "co_nlocals", "co_stacksize", "co_flags", "co_code", "co_consts", "co_names", "co_varnames", "co_filename", "co_name", "co_firstlineno", "co_lnotab", "co_freevars", "co_cellvars"],
+        (3, 7):  ["co_argcount", "co_kwonlyargcount", "co_nlocals", "co_stacksize", "co_flags", "co_code", "co_consts", "co_names", "co_varnames", "co_filename", "co_name", "co_firstlineno", "co_lnotab", "co_freevars", "co_cellvars"],
+        (3, 8):  ["co_argcount", "co_posonlyargcount", "co_kwonlyargcount", "co_nlocals", "co_stacksize", "co_flags", "co_code", "co_consts", "co_names", "co_varnames", "co_filename", "co_name", "co_firstlineno", "co_lnotab", "co_freevars", "co_cellvars"],
+        (3, 9):  ["co_argcount", "co_posonlyargcount", "co_kwonlyargcount", "co_nlocals", "co_stacksize", "co_flags", "co_code", "co_consts", "co_names", "co_varnames", "co_filename", "co_name", "co_firstlineno", "co_lnotab", "co_freevars", "co_cellvars"],
+        (3, 10): ["co_argcount", "co_posonlyargcount", "co_kwonlyargcount", "co_nlocals", "co_stacksize", "co_flags", "co_code", "co_consts", "co_names", "co_varnames", "co_filename", "co_name", "co_firstlineno", "co_linetable", "co_freevars", "co_cellvars"],
+        (3, 11): ["co_argcount", "co_posonlyargcount", "co_kwonlyargcount", "co_nlocals", "co_stacksize", "co_flags", "co_code", "co_consts", "co_names", "co_varnames", "co_filename", "co_name", "co_qualname", "co_firstlineno", "co_linetable", "co_exceptiontable", "co_freevars", "co_cellvars"]
+    }
+
+    version, minor = sys.version_info[0], sys.version_info[1]
+
+    # Clamp major version to 2 or 3
+    version = max(min(version, 3), 2)
+
+    # Clamp minor version to 7-11
+    minor = max(min(minor, 11), 7)
+
+    attrs = version_lookup[(version, minor)]
 
     assert all( k in attrs for k in kwds ), \
         "Invalid function keyword(s) supplied: %s" % ( ", ".join( kwds.keys() ))


### PR DESCRIPTION
I had an import failing when trying to run my `cpppo` code in python 3.11:

```
  File "/Users/maxj/Documents/Charge/factory/factory/drivers/al1120.py", line 16, in <module>
    from cpppo.server.enip.get_attribute import proxy_simple
  File "/Users/maxj/Library/Caches/pypoetry/virtualenvs/factory-4i3Wbpjw-py3.11/lib/python3.11/site-packages/cpppo/__init__.py", line 29, in <module>
    from .automata import *
  File "/Users/maxj/Library/Caches/pypoetry/virtualenvs/factory-4i3Wbpjw-py3.11/lib/python3.11/site-packages/cpppo/automata.py", line 33, in <module>
    from . import misc
  File "/Users/maxj/Library/Caches/pypoetry/virtualenvs/factory-4i3Wbpjw-py3.11/lib/python3.11/site-packages/cpppo/misc.py", line 221, in <module>
    change_function( __normal, co_filename=logging._srcfile )
  File "/Users/maxj/Library/Caches/pypoetry/virtualenvs/factory-4i3Wbpjw-py3.11/lib/python3.11/site-packages/cpppo/misc.py", line 180, in change_function
    modi_code			= types.CodeType( *modi_args )
```

I looked into this and it looked like there was some python-version-specific code in `misc.py`.

In addition to adding support for python version 3.11, I also noticed what I think is a bug in the existing code. If you run `help(types.CodeType)` in a python 3.8, 3.9, or 3.10 shell, you'll see that the second argument to `code` is `posonlyargcount`, but in the current code it is assumed to be `kwonlyargcount`. I fixed that in this PR as well.

I tested this by running the import in python versions 3.7, 3.9, 3.10, and 3.11. I did not test in python 2.

It would be cool if someone with more knowledge of this code than me could kill this function entirely! Also I didn't see any CONTRIBUTING docs, so apologies if I'm doing this wrong. Thank you!