### PR TITLE
support set_attributes_all (service 0x02)

### DIFF
--- a/server/enip/device.py
+++ b/server/enip/device.py
@@ -920,6 +920,11 @@ class Object( object ):
     GA_ALL_REQ			= 0x01
     GA_ALL_RPY			= GA_ALL_REQ | 0x80
 
+    SA_ALL_NAM          = "Set Attributes All"
+    SA_ALL_CTX          = "set_attributes_all"
+    SA_ALL_REQ          = 0x02
+    SA_ALL_RPY          = SA_ALL_REQ | 0x80
+
     GA_LST_NAM			= "Get Attribute List"
     GA_LST_CTX			= "get_attribute_list"
     GA_LST_REQ			= 0x03
@@ -1062,6 +1067,9 @@ class Object( object ):
             elif ( data.get( 'service' ) == self.GA_ALL_REQ
                  or self.GA_ALL_CTX in data and data.setdefault( 'service', self.GA_ALL_REQ ) == self.GA_ALL_REQ ):
                 pass
+            elif ( data.get( 'service' ) == self.SA_ALL_REQ
+                 or self.SA_ALL_CTX in data and data.setdefault( 'service', self.SA_ALL_REQ ) == self.SA_ALL_REQ ):
+                pass
             elif ( data.get( 'service' ) == self.SA_SNG_REQ
                  or self.SA_SNG_CTX in data and data.setdefault( 'service', self.SA_SNG_REQ ) == self.SA_SNG_REQ ):
                 pass
@@ -1086,6 +1094,38 @@ class Object( object ):
                 data.get_attributes_all = dotdict()
                 data.get_attributes_all.data = [
                     b if type( b ) is int else ord( b ) for b in result ]
+            elif data.service == self.SA_ALL_RPY:
+                # Set Attributes All.  Convert unsigned ints to bytes, parse appropriate
+                # elements using the Attribute's .parser, and assign.  Must produce exactly the
+                # correct number of bytes to fully populate the Attributes.
+                
+                a_id = 1
+                sum_siz = 0
+                while str(a_id) in self.attribute:
+                
+                    att = self.attribute[str(a_id)]
+                    att_siz = att.parser.struct_calcsize * len(att)
+                    sum_siz += att_siz
+                    a_id += 1
+
+                assert 'set_attributes_all.data' in data and len(data.set_attributes_all.data) == sum_siz, \
+                        "Expected %d total bytes in .set_attributes_all.data" % (sum_siz,)
+
+                a_id = 1
+                data_ptr = 0
+                while str(a_id) in self.attribute:
+
+                    att = self.attribute[str(a_id)]
+                    siz = att.parser.struct_calcsize
+                    att_siz = siz * len(att)
+                    fmt     = att.parser.struct_format
+                    buf = bytearray( data.set_attributes_all.data[data_ptr:data_ptr + att_siz] )
+                    val = [struct.unpack( fmt, buf[i:i+siz] )[0]
+                                    for i in range(0, len(buf), siz) ]
+                    att[:]  = val
+                    a_id += 1
+                    data_ptr += att_siz
+                    
             elif data.service == self.GA_LST_RPY:
                 # Get Attribute List.  Collect up the bytes representing the attributes.  Converts a
                 # placehold .get_attribute_list = [<attribute>,...] list of attribute numbers with
@@ -1217,6 +1257,12 @@ class Object( object ):
             # Get Attributes All
             result	       += USINT.produce(	data.service )
             result	       += EPATH.produce(	data.path )
+        elif cls.SA_ALL_CTX in data and data.setdefault( 'service', cls.SA_ALL_REQ ) == cls.SA_ALL_REQ:
+            # Set Attributes All
+            result         += USINT.produce(    data.service )
+            result         += EPATH.produce(    data.path )
+            result         += typed_data.produce(   data.set_attributes_all,
+                                                        tag_type=USINT.tag_type )
         elif cls.GA_SNG_CTX in data and data.setdefault( 'service', cls.GA_SNG_REQ ) == cls.GA_SNG_REQ:
             # Get Attribute Single
             result	       += USINT.produce(	data.service )
@@ -1242,6 +1288,12 @@ class Object( object ):
             if data.status == 0x00:
                 result	       += typed_data.produce( 	data.get_attributes_all,
                                                         tag_type=USINT.tag_type )
+        elif data.get( 'service' ) == cls.SA_ALL_RPY:
+            # Set Attributes All Reply.
+            result         += USINT.produce(    data.service )
+            result         += b'\x00' # reserved
+            result         += status.produce(   data )
+
         elif data.get( 'service' ) == cls.GA_LST_RPY:
             # Get Attribute List Reply
             result	       += USINT.produce(	data.service )
@@ -1327,6 +1379,29 @@ def __get_attributes_all_reply():
 
 Object.register_service_parser( number=Object.GA_ALL_RPY, name=Object.GA_ALL_NAM + " Reply",
                                 short=Object.GA_ALL_CTX, machine=__get_attributes_all_reply() )
+
+def __set_attributes_all( ):
+    srvc            = USINT(            context='service' )
+    srvc[True]      = path  = EPATH(            context='path')
+    path[True]          = typed_data(           context=Object.SA_ALL_CTX,
+                                                tag_type=USINT.tag_type,
+                                                terminal=True )
+    return srvc
+
+Object.register_service_parser( number=Object.SA_ALL_REQ, name=Object.SA_ALL_NAM,
+                                short=Object.SA_ALL_CTX, machine=__set_attributes_all() )
+
+def __set_attributes_all_reply():
+    srvc            = USINT(            context='service' )
+    srvc[True]      = rsvd  = octets_drop(  'reserved', repeat=1 )
+    rsvd[True]      = stts  = status()
+    stts[None]      = mark  = octets_noop(          context=Object.SA_ALL_CTX,
+                                                terminal=True )
+    mark.initial[None]      = move_if(  'mark',     initializer=True )
+    return srvc
+
+Object.register_service_parser( number=Object.SA_ALL_RPY, name=Object.SA_ALL_NAM + " Reply",
+                                short=Object.SA_ALL_CTX, machine=__set_attributes_all_reply() )
 
 def __get_attribute_list():
     srvc			= USINT(		 	context='service' )

--- a/server/enip/get_attribute.py
+++ b/server/enip/get_attribute.py
@@ -101,8 +101,7 @@ def attribute_operations( paths, int_type=None, **kwds ):
     for op in client.parse_operations( paths, int_type=int_type or 'SINT', **kwds ):
         path_end		= op['path'][-1]
         if 'instance' in path_end:
-            op['method'] = 'get_attributes_all'
-            assert 'data' not in op, "All Attributes cannot be operated on using Set Attribute services"
+            op['method'] = 'set_attributes_all' if 'data' in op else 'get_attributes_all'
         elif 'symbolic' in path_end or 'attribute' in path_end or 'element' in path_end:
             op['method'] = 'set_attribute_single' if 'data' in op else 'get_attribute_single'
         else:


### PR DESCRIPTION
i needed support for set_attributes_all for simulation purposes, using `pycomm3` as a client library and `cpppo` as the Ethernet/IP server (no Logix). i am pretty sure someone else can benefit from this.

**example/how to**

set up server with two attributes in the same object `0x80/1`:

`python3 -m cpppo.server.enip --print my_uint32@0x80/1/1=UDINT my_int16@0x80/1/2=INT`

set all the objects attributes at once using a byte array (hex parsing is supported). in this example, the first four bytes `b'\x13\x00\x00\x00' == UDINT.produce(19)` target the unsigned 32-bit integer and the last two bytes `b'\xfe\xff' == INT.produce(-2)` are meant for the signed 16-bit integer:

`python3 -m cpppo.server.enip.get_attribute -a localhost @0x80/1=0x13,0x00,0x00,0x00,0xfe,0xff`

this will result in the following output on the server side

```
  my_uint32[    0-0    ] <= [19] 
   my_int16[    0-0    ] <= [-2]
```

and on the client side

``
Fri Sep 27 15:51:43 2024:   0: Single S_A_A     @0x0080/1 == True
``

**details**

- added support for `set_attributes_all` requests in server and client
- extended `server.enip.get_attribute` to naturally support `set_attributes_all`
- added hex parsing in `server.enip.client`