### PR TITLE
Fix Python 2 setup extras requirement loading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ extras_require			= {
     option: list(
         # Remove whitespace, elide blank lines and comments
         ''.join( r.split() )
-        for r in open( os.path.join( HERE, f"requirements-{option}.txt" )).readlines()
+        for r in open( os.path.join( HERE, "requirements-{0}.txt".format( option ))).readlines()
         if r.strip() and not r.strip().startswith( '#' )
     )
     for option in options_require


### PR DESCRIPTION
## Summary

Make setup.py parse requirement extras without Python 3-only f-string syntax.

The package still supports Python 2, but setup.py used an f-string while building extras_require. That makes setup.py fail to parse under Python 2 before installation metadata can be inspected.

## Changes

- Replace the f-string expression in setup.py with str.format().
- Keep the generated extras keys unchanged.

## Testing

- py -2.7 setup.py --version
- python setup.py --version