### PR TITLE
Make ENIP tests tolerate missing root log handlers

### DIFF
--- a/server/enip/parser_test.py
+++ b/server/enip/parser_test.py
@@ -20,6 +20,8 @@ from ... import misc
 
 # Set up logging to use our log format (instead of default Pytest format), while
 # retaining any logging level eg. python -m pytest --log-cli-level=25 ...
+if not logging.getLogger().handlers:
+    logging.basicConfig( **log_cfg )
 logging.getLogger().handlers[0].setFormatter( logging.Formatter( log_cfg['format'] ))
 
 

--- a/server/enip/udt_test.py
+++ b/server/enip/udt_test.py
@@ -20,6 +20,8 @@ from . import defaults, udt, parser, device, logix, ucmm
 
 # Set up logging to use our log format (instead of default Pytest format), while
 # retaining any logging level eg. python -m pytest --log-cli-level=25 ...
+if not logging.getLogger().handlers:
+    logging.basicConfig( **log_cfg )
 logging.getLogger().handlers[0].setFormatter( logging.Formatter( log_cfg['format'] ))
 
 try:


### PR DESCRIPTION
## Summary

Allow ENIP parser and UDT tests to be collected when pytest has not installed a root logging handler yet.

Some Python 2 / pytest environments leave the root logger without handlers during test module import. The existing tests immediately access handlers[0], which raises IndexError during collection before the tests can run.

## Changes

- Configure default logging with logging.basicConfig(**log_cfg) only when the root logger has no handlers.
- Preserve the existing formatter behavior when a handler is already present.

## Testing

- py -2.7 -m pytest server/enip/parser_test.py server/enip/udt_test.py